### PR TITLE
Use custom errors in FulfillmentLib

### DIFF
--- a/src/fulfillments/lib/FulfillmentLib.sol
+++ b/src/fulfillments/lib/FulfillmentLib.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {LibPRNG} from "solady/src/utils/LibPRNG.sol";
+import { LibPRNG } from "solady/src/utils/LibPRNG.sol";
 
-import {LibSort} from "solady/src/utils/LibSort.sol";
+import { LibSort } from "solady/src/utils/LibSort.sol";
 
 import {
     FulfillmentComponent,
@@ -16,9 +16,9 @@ import {
     CriteriaResolver
 } from "../../SeaportStructs.sol";
 
-import {ItemType, Side} from "../../SeaportEnums.sol";
+import { ItemType, Side } from "../../SeaportEnums.sol";
 
-import {MatchComponent, OrderDetails} from "./Structs.sol";
+import { MatchComponent, OrderDetails } from "./Structs.sol";
 
 enum FulfillmentEligibility {
     NONE,
@@ -31,7 +31,7 @@ enum AggregationStrategy {
     MINIMUM, // Aggregate as few items as possible
     MAXIMUM, // Aggregate as many items as possible
     RANDOM // Randomize aggregation quantity
-        // NOTE: for match cases, there may be more sophisticated optimal strategies
+    // NOTE: for match cases, there may be more sophisticated optimal strategies
 }
 
 enum FulfillAvailableStrategy {
@@ -53,7 +53,7 @@ enum MatchStrategy {
     MAX_EXECUTIONS, // use as many fulfillments as possible given aggregations
     MIN_EXECUTIONS, // use as few fulfillments as possible given aggregations
     MIN_EXECUTIONS_MAX_FILTERS // minimize fulfillments and prioritize filters
-        // NOTE: more sophisticated match strategies require modifying aggregations
+    // NOTE: more sophisticated match strategies require modifying aggregations
 }
 
 enum ItemCategory {
@@ -111,16 +111,48 @@ library FulfillmentGeneratorLib {
     using ItemReferenceLib for OrderDetails[];
     using FulfillmentPrepLib for ItemReferenceLib.ItemReference[];
 
-    function getDefaultFulfillmentStrategy() internal pure returns (FulfillmentStrategy memory) {
-        return FulfillmentStrategy({
-            aggregationStrategy: AggregationStrategy.MAXIMUM,
-            fulfillAvailableStrategy: FulfillAvailableStrategy.KEEP_ALL,
-            matchStrategy: MatchStrategy.MAX_INCLUSION
-        });
+    error UnsupportedFulfillAvailableStrategy();
+    error UnsupportedMatchStrategy();
+    error UnknownMatchAggregationStrategy();
+    error EmptyConsiderationArray();
+    error EmptyConsiderationItems();
+    error OutOfRangeConsiderationItemIndex();
+    error EmptyOfferArray();
+    error EmptyOfferItems();
+    error OutOfRangeOfferItemIndex();
+    error UnspentMatchItemAssignmentError();
+    error UnmetMatchItemAssignmentError();
+    error UnspentMatchAmountOfZero();
+    error UnmetMatchAmountOfZero();
+    error DidNotCompleteProcessing();
+    error MissingItemAmountsToConsume();
+    error DidNotConsumeExpectedAmount();
+    error DidNotCreditExpectedAmount();
+    error EmptyMatchComponentGenerated();
+    error DidNotFindConsumableItems();
+    error StrategyUnsupported();
+    error UnknownFulfillAvailableStrategy();
+    error UnknownAggregationStrategy();
+
+    function getDefaultFulfillmentStrategy()
+        internal
+        pure
+        returns (FulfillmentStrategy memory)
+    {
+        return
+            FulfillmentStrategy({
+                aggregationStrategy: AggregationStrategy.MAXIMUM,
+                fulfillAvailableStrategy: FulfillAvailableStrategy.KEEP_ALL,
+                matchStrategy: MatchStrategy.MAX_INCLUSION
+            });
     }
 
     // This uses the "default" set of strategies and applies no randomization.
-    function getFulfillments(OrderDetails[] memory orderDetails, address recipient, address caller)
+    function getFulfillments(
+        OrderDetails[] memory orderDetails,
+        address recipient,
+        address caller
+    )
         internal
         pure
         returns (
@@ -134,7 +166,14 @@ library FulfillmentGeneratorLib {
     {
         uint256 seed = 0;
 
-        return getFulfillments(orderDetails, getDefaultFulfillmentStrategy(), recipient, caller, seed);
+        return
+            getFulfillments(
+                orderDetails,
+                getDefaultFulfillmentStrategy(),
+                recipient,
+                caller,
+                seed
+            );
     }
 
     function getFulfillments(
@@ -155,12 +194,21 @@ library FulfillmentGeneratorLib {
             MatchComponent[] memory unmetConsiderationComponents
         )
     {
-        ItemReferenceLib.ItemReference[] memory references = orderDetails.getItemReferences(seed);
+        ItemReferenceLib.ItemReference[] memory references = orderDetails
+            .getItemReferences(seed);
 
-        (FulfillAvailableDetails memory fulfillAvailableDetails, MatchDetails memory matchDetails) =
-            references.getDetails(recipient, caller);
+        (
+            FulfillAvailableDetails memory fulfillAvailableDetails,
+            MatchDetails memory matchDetails
+        ) = references.getDetails(recipient, caller);
 
-        return getFulfillmentsFromDetails(fulfillAvailableDetails, matchDetails, strategy, seed);
+        return
+            getFulfillmentsFromDetails(
+                fulfillAvailableDetails,
+                matchDetails,
+                strategy,
+                seed
+            );
     }
 
     function getFulfillmentsFromDetails(
@@ -182,26 +230,43 @@ library FulfillmentGeneratorLib {
     {
         assertSupportedStrategy(strategy);
 
-        (fulfillments, unspentOfferComponents, unmetConsiderationComponents) =
-            getMatchFulfillments(matchDetails, strategy, seed);
+        (
+            fulfillments,
+            unspentOfferComponents,
+            unmetConsiderationComponents
+        ) = getMatchFulfillments(matchDetails, strategy, seed);
 
-        eligibility = determineEligibility(fulfillAvailableDetails, unmetConsiderationComponents.length);
+        eligibility = determineEligibility(
+            fulfillAvailableDetails,
+            unmetConsiderationComponents.length
+        );
 
-        if (eligibility == FulfillmentEligibility.FULFILL_AVAILABLE || eligibility == FulfillmentEligibility.BOTH) {
-            (offerFulfillments, considerationFulfillments) =
-                getFulfillAvailableFulfillments(fulfillAvailableDetails, strategy, seed);
+        if (
+            eligibility == FulfillmentEligibility.FULFILL_AVAILABLE ||
+            eligibility == FulfillmentEligibility.BOTH
+        ) {
+            (
+                offerFulfillments,
+                considerationFulfillments
+            ) = getFulfillAvailableFulfillments(
+                fulfillAvailableDetails,
+                strategy,
+                seed
+            );
         }
     }
 
-    function assertSupportedStrategy(FulfillmentStrategy memory strategy) internal pure {
+    function assertSupportedStrategy(
+        FulfillmentStrategy memory strategy
+    ) internal pure {
         // TODO: add more strategies here as support is added for them.
         if (uint256(strategy.fulfillAvailableStrategy) > 3) {
-            revert("FulfillmentGeneratorLib: unsupported fulfillAvailable strategy");
+            revert UnsupportedFulfillAvailableStrategy();
         }
 
         MatchStrategy matchStrategy = strategy.matchStrategy;
         if (matchStrategy != MatchStrategy.MAX_INCLUSION) {
-            revert("FulfillmentGeneratorLib: unsupported match strategy");
+            revert UnsupportedMatchStrategy();
         }
     }
 
@@ -214,22 +279,32 @@ library FulfillmentGeneratorLib {
         // There must also be at least one unfiltered explicit execution. Note
         // that it is also *very* tricky to use FulfillAvailable in cases where
         // ERC721 items are present on both the offer side & consideration side.
-        bool eligibleForFulfillAvailable = determineFulfillAvailableEligibility(fulfillAvailableDetails);
+        bool eligibleForFulfillAvailable = determineFulfillAvailableEligibility(
+            fulfillAvailableDetails
+        );
 
         // Match: cannot be used if there is no way to meet each consideration
         // item. In these cases, remaining offer components should be returned.
         bool eligibleForMatch = totalUnmetConsiderationComponents == 0;
 
         if (eligibleForFulfillAvailable) {
-            return eligibleForMatch ? FulfillmentEligibility.BOTH : FulfillmentEligibility.FULFILL_AVAILABLE;
+            return
+                eligibleForMatch
+                    ? FulfillmentEligibility.BOTH
+                    : FulfillmentEligibility.FULFILL_AVAILABLE;
         }
 
-        return eligibleForMatch ? FulfillmentEligibility.MATCH : FulfillmentEligibility.NONE;
+        return
+            eligibleForMatch
+                ? FulfillmentEligibility.MATCH
+                : FulfillmentEligibility.NONE;
     }
 
     // This uses the "default" set of strategies, applies no randomization, and
     // does not give a recipient & will not properly detect filtered executions.
-    function getMatchedFulfillments(OrderDetails[] memory orderDetails)
+    function getMatchedFulfillments(
+        OrderDetails[] memory orderDetails
+    )
         internal
         pure
         returns (
@@ -238,7 +313,12 @@ library FulfillmentGeneratorLib {
             MatchComponent[] memory unmetConsiderationComponents
         )
     {
-        return getMatchFulfillments(orderDetails.getItemReferences(0).getMatchDetailsFromReferences(address(0)));
+        return
+            getMatchFulfillments(
+                orderDetails.getItemReferences(0).getMatchDetailsFromReferences(
+                    address(0)
+                )
+            );
     }
 
     // This does not give a recipient & so will not detect filtered executions.
@@ -255,9 +335,14 @@ library FulfillmentGeneratorLib {
             MatchComponent[] memory unmetConsiderationComponents
         )
     {
-        return getMatchFulfillments(
-            orderDetails.getItemReferences(0).getMatchDetailsFromReferences(address(0)), strategy, seed
-        );
+        return
+            getMatchFulfillments(
+                orderDetails.getItemReferences(0).getMatchDetailsFromReferences(
+                    address(0)
+                ),
+                strategy,
+                seed
+            );
     }
 
     function getMatchDetails(
@@ -274,13 +359,20 @@ library FulfillmentGeneratorLib {
             MatchComponent[] memory unmetConsiderationComponents
         )
     {
-        return getMatchFulfillments(
-            orderDetails.getItemReferences(seed).getMatchDetailsFromReferences(recipient), strategy, seed
-        );
+        return
+            getMatchFulfillments(
+                orderDetails
+                    .getItemReferences(seed)
+                    .getMatchDetailsFromReferences(recipient),
+                strategy,
+                seed
+            );
     }
 
     // This uses the "default" set of strategies and applies no randomization.
-    function getMatchFulfillments(MatchDetails memory matchDetails)
+    function getMatchFulfillments(
+        MatchDetails memory matchDetails
+    )
         internal
         pure
         returns (
@@ -291,10 +383,19 @@ library FulfillmentGeneratorLib {
     {
         uint256 seed = 0;
 
-        return getMatchFulfillments(matchDetails, getDefaultFulfillmentStrategy(), seed);
+        return
+            getMatchFulfillments(
+                matchDetails,
+                getDefaultFulfillmentStrategy(),
+                seed
+            );
     }
 
-    function getMatchFulfillments(MatchDetails memory matchDetails, FulfillmentStrategy memory strategy, uint256 seed)
+    function getMatchFulfillments(
+        MatchDetails memory matchDetails,
+        FulfillmentStrategy memory strategy,
+        uint256 seed
+    )
         internal
         pure
         returns (
@@ -306,23 +407,30 @@ library FulfillmentGeneratorLib {
         MatchStrategy matchStrategy = strategy.matchStrategy;
 
         if (matchStrategy == MatchStrategy.MAX_INCLUSION) {
-            (fulfillments, unspentOfferComponents, unmetConsiderationComponents) =
-            getMatchFulfillmentsUsingConsumeMethod(
-                matchDetails, getMaxInclusionConsumeMethod(strategy.aggregationStrategy), seed
+            (
+                fulfillments,
+                unspentOfferComponents,
+                unmetConsiderationComponents
+            ) = getMatchFulfillmentsUsingConsumeMethod(
+                matchDetails,
+                getMaxInclusionConsumeMethod(strategy.aggregationStrategy),
+                seed
             );
         } else {
-            revert("FulfillmentGeneratorLib: unsupported match strategy");
+            revert UnsupportedMatchStrategy();
         }
     }
 
-    function getMaxInclusionConsumeMethod(AggregationStrategy aggregationStrategy)
+    function getMaxInclusionConsumeMethod(
+        AggregationStrategy aggregationStrategy
+    )
         internal
         pure
         returns (
             function(FulfillmentItems memory, FulfillmentItems memory, uint256)
-                                internal
-                                pure
-                                returns (Fulfillment memory)
+                internal
+                pure
+                returns (Fulfillment memory)
         )
     {
         if (aggregationStrategy == AggregationStrategy.MAXIMUM) {
@@ -332,39 +440,59 @@ library FulfillmentGeneratorLib {
         } else if (aggregationStrategy == AggregationStrategy.RANDOM) {
             return consumeRandomItemsAndGetFulfillment;
         } else {
-            revert("FulfillmentGeneratorLib: unknown match aggregation strategy");
+            revert UnknownMatchAggregationStrategy();
         }
     }
 
-    function getTotalUncoveredComponents(DualFulfillmentMatchContext[] memory contexts)
+    function getTotalUncoveredComponents(
+        DualFulfillmentMatchContext[] memory contexts
+    )
         internal
         pure
-        returns (uint256 totalUnspentOfferComponents, uint256 totalUnmetConsiderationComponents)
+        returns (
+            uint256 totalUnspentOfferComponents,
+            uint256 totalUnmetConsiderationComponents
+        )
     {
         for (uint256 i = 0; i < contexts.length; ++i) {
             DualFulfillmentMatchContext memory context = contexts[i];
 
             if (context.totalConsiderationAmount > context.totalOfferAmount) {
                 ++totalUnmetConsiderationComponents;
-            } else if (context.totalConsiderationAmount < context.totalOfferAmount) {
+            } else if (
+                context.totalConsiderationAmount < context.totalOfferAmount
+            ) {
                 ++totalUnspentOfferComponents;
             }
         }
     }
 
-    function getUncoveredComponents(MatchDetails memory matchDetails)
+    function getUncoveredComponents(
+        MatchDetails memory matchDetails
+    )
         internal
         pure
-        returns (MatchComponent[] memory unspentOfferComponents, MatchComponent[] memory unmetConsiderationComponents)
+        returns (
+            MatchComponent[] memory unspentOfferComponents,
+            MatchComponent[] memory unmetConsiderationComponents
+        )
     {
-        (uint256 totalUnspentOfferComponents, uint256 totalUnmetConsiderationComponents) =
-            getTotalUncoveredComponents(matchDetails.context);
+        (
+            uint256 totalUnspentOfferComponents,
+            uint256 totalUnmetConsiderationComponents
+        ) = getTotalUncoveredComponents(matchDetails.context);
 
-        unspentOfferComponents = (new MatchComponent[](totalUnspentOfferComponents));
+        unspentOfferComponents = (
+            new MatchComponent[](totalUnspentOfferComponents)
+        );
 
-        unmetConsiderationComponents = (new MatchComponent[](totalUnmetConsiderationComponents));
+        unmetConsiderationComponents = (
+            new MatchComponent[](totalUnmetConsiderationComponents)
+        );
 
-        if (totalUnspentOfferComponents + totalUnmetConsiderationComponents == 0) {
+        if (
+            totalUnspentOfferComponents + totalUnmetConsiderationComponents == 0
+        ) {
             return (unspentOfferComponents, unmetConsiderationComponents);
         }
 
@@ -372,52 +500,70 @@ library FulfillmentGeneratorLib {
         totalUnmetConsiderationComponents = 0;
 
         for (uint256 i = 0; i < matchDetails.items.length; ++i) {
-            DualFulfillmentMatchContext memory context = (matchDetails.context[i]);
+            DualFulfillmentMatchContext memory context = (
+                matchDetails.context[i]
+            );
 
             FulfillmentItems[] memory offer = matchDetails.items[i].offer;
 
-            FulfillmentItems[] memory consideration = (matchDetails.items[i].consideration);
+            FulfillmentItems[] memory consideration = (
+                matchDetails.items[i].consideration
+            );
 
             if (context.totalConsiderationAmount > context.totalOfferAmount) {
-                uint256 amount = (context.totalConsiderationAmount - context.totalOfferAmount);
+                uint256 amount = (context.totalConsiderationAmount -
+                    context.totalOfferAmount);
 
                 if (consideration.length == 0) {
-                    revert("FulfillmentGeneratorLib: empty consideration array");
+                    revert EmptyConsiderationArray();
                 }
 
                 if (consideration[0].items.length == 0) {
-                    revert("FulfillmentGeneratorLib: empty consideration items");
+                    revert EmptyConsiderationItems();
                 }
 
                 FulfillmentItem memory item = consideration[0].items[0];
 
-                if (item.orderIndex > type(uint8).max || item.itemIndex > type(uint8).max) {
-                    revert("FulfillmentGeneratorLib: OOR consideration item index");
+                if (
+                    item.orderIndex > type(uint8).max ||
+                    item.itemIndex > type(uint8).max
+                ) {
+                    revert OutOfRangeConsiderationItemIndex();
                 }
 
-                unmetConsiderationComponents[totalUnmetConsiderationComponents++] = MatchComponent({
+                unmetConsiderationComponents[
+                    totalUnmetConsiderationComponents++
+                ] = MatchComponent({
                     amount: amount,
                     orderIndex: uint8(item.orderIndex),
                     itemIndex: uint8(item.itemIndex)
                 });
-            } else if (context.totalConsiderationAmount < context.totalOfferAmount) {
-                uint256 amount = (context.totalOfferAmount - context.totalConsiderationAmount);
+            } else if (
+                context.totalConsiderationAmount < context.totalOfferAmount
+            ) {
+                uint256 amount = (context.totalOfferAmount -
+                    context.totalConsiderationAmount);
 
                 if (offer.length == 0) {
-                    revert("FulfillmentGeneratorLib: empty offer array");
+                    revert EmptyOfferArray();
                 }
 
                 if (offer[0].items.length == 0) {
-                    revert("FulfillmentGeneratorLib: empty offer items");
+                    revert EmptyOfferItems();
                 }
 
                 FulfillmentItem memory item = offer[0].items[0];
 
-                if (item.orderIndex > type(uint8).max || item.itemIndex > type(uint8).max) {
-                    revert("FulfillmentGeneratorLib: OOR offer item index");
+                if (
+                    item.orderIndex > type(uint8).max ||
+                    item.itemIndex > type(uint8).max
+                ) {
+                    revert OutOfRangeOfferItemIndex();
                 }
 
-                unspentOfferComponents[totalUnspentOfferComponents++] = MatchComponent({
+                unspentOfferComponents[
+                    totalUnspentOfferComponents++
+                ] = MatchComponent({
                     amount: amount,
                     orderIndex: uint8(item.orderIndex),
                     itemIndex: uint8(item.itemIndex)
@@ -427,22 +573,25 @@ library FulfillmentGeneratorLib {
 
         // Sanity checks
         if (unspentOfferComponents.length != totalUnspentOfferComponents) {
-            revert("FulfillmentGeneratorLib: unspent match item assignment error");
+            revert UnspentMatchItemAssignmentError();
         }
 
-        if (unmetConsiderationComponents.length != totalUnmetConsiderationComponents) {
-            revert("FulfillmentGeneratorLib: unmet match item assignment error");
+        if (
+            unmetConsiderationComponents.length !=
+            totalUnmetConsiderationComponents
+        ) {
+            revert UnmetMatchItemAssignmentError();
         }
 
         for (uint256 i = 0; i < unspentOfferComponents.length; ++i) {
             if (unspentOfferComponents[i].amount == 0) {
-                revert("FulfillmentGeneratorLib: unspent match amount of zero");
+                revert UnspentMatchAmountOfZero();
             }
         }
 
         for (uint256 i = 0; i < unmetConsiderationComponents.length; ++i) {
             if (unmetConsiderationComponents[i].amount == 0) {
-                revert("FulfillmentGeneratorLib: unmet match amount of zero");
+                revert UnmetMatchAmountOfZero();
             }
         }
     }
@@ -464,10 +613,17 @@ library FulfillmentGeneratorLib {
         )
     {
         if (matchDetails.totalItems == 0) {
-            return (fulfillments, unspentOfferComponents, unmetConsiderationComponents);
+            return (
+                fulfillments,
+                unspentOfferComponents,
+                unmetConsiderationComponents
+            );
         }
 
-        (unspentOfferComponents, unmetConsiderationComponents) = getUncoveredComponents(matchDetails);
+        (
+            unspentOfferComponents,
+            unmetConsiderationComponents
+        ) = getUncoveredComponents(matchDetails);
 
         // Allocate based on max possible fulfillments; reduce after assignment.
         fulfillments = new Fulfillment[](matchDetails.totalItems - 1);
@@ -478,7 +634,11 @@ library FulfillmentGeneratorLib {
             // This is actually a "while" loop, but bound it as a sanity check.
             bool allProcessed = false;
             for (uint256 j = 0; j < matchDetails.totalItems; ++j) {
-                Fulfillment memory fulfillment = consumeItems(matchDetails.items[i], consumeMethod, seed);
+                Fulfillment memory fulfillment = consumeItems(
+                    matchDetails.items[i],
+                    consumeMethod,
+                    seed
+                );
 
                 // Exit the inner loop if no fulfillment was located.
                 if (fulfillment.offerComponents.length == 0) {
@@ -490,7 +650,7 @@ library FulfillmentGeneratorLib {
                 fulfillments[currentFulfillment++] = fulfillment;
             }
             if (!allProcessed) {
-                revert("FulfillmentGeneratorLib: did not complete processing");
+                revert DidNotCompleteProcessing();
             }
         }
 
@@ -515,10 +675,13 @@ library FulfillmentGeneratorLib {
             if (offerItems.totalAmount != 0) {
                 // Search for something it can be matched against.
                 for (uint256 j = 0; j < matchItems.consideration.length; ++j) {
-                    FulfillmentItems memory considerationItems = (matchItems.consideration[j]);
+                    FulfillmentItems memory considerationItems = (
+                        matchItems.consideration[j]
+                    );
 
                     if (considerationItems.totalAmount != 0) {
-                        return consumeMethod(offerItems, considerationItems, seed);
+                        return
+                            consumeMethod(offerItems, considerationItems, seed);
                     }
                 }
             }
@@ -533,13 +696,19 @@ library FulfillmentGeneratorLib {
         FulfillmentItems memory considerationItems,
         uint256 /* seed */
     ) internal pure returns (Fulfillment memory) {
-        if (offerItems.totalAmount == 0 || considerationItems.totalAmount == 0) {
-            revert("FulfillmentGeneratorLib: missing item amounts to consume");
+        if (
+            offerItems.totalAmount == 0 || considerationItems.totalAmount == 0
+        ) {
+            revert MissingItemAmountsToConsume();
         }
 
         // Allocate fulfillment component arrays with a single element.
-        FulfillmentComponent[] memory offerComponents = (new FulfillmentComponent[](1));
-        FulfillmentComponent[] memory considerationComponents = (new FulfillmentComponent[](1));
+        FulfillmentComponent[] memory offerComponents = (
+            new FulfillmentComponent[](1)
+        );
+        FulfillmentComponent[] memory considerationComponents = (
+            new FulfillmentComponent[](1)
+        );
 
         FulfillmentItem memory offerItem;
         for (uint256 i = 0; i < offerItems.items.length; ++i) {
@@ -574,7 +743,11 @@ library FulfillmentGeneratorLib {
             considerationItem.amount = 0;
         }
 
-        return Fulfillment({offerComponents: offerComponents, considerationComponents: considerationComponents});
+        return
+            Fulfillment({
+                offerComponents: offerComponents,
+                considerationComponents: considerationComponents
+            });
     }
 
     function consumeMaximumItemsAndGetFulfillment(
@@ -582,19 +755,25 @@ library FulfillmentGeneratorLib {
         FulfillmentItems memory considerationItems,
         uint256 /* seed */
     ) internal pure returns (Fulfillment memory) {
-        if (offerItems.totalAmount == 0 || considerationItems.totalAmount == 0) {
-            revert("FulfillmentGeneratorLib: missing item amounts to consume");
+        if (
+            offerItems.totalAmount == 0 || considerationItems.totalAmount == 0
+        ) {
+            revert MissingItemAmountsToConsume();
         }
 
         // Allocate fulfillment component arrays using total items; reduce
         // length after based on the total number of elements assigned to each.
-        FulfillmentComponent[] memory offerComponents = (new FulfillmentComponent[](offerItems.items.length));
-        FulfillmentComponent[] memory considerationComponents =
-            (new FulfillmentComponent[](considerationItems.items.length));
+        FulfillmentComponent[] memory offerComponents = (
+            new FulfillmentComponent[](offerItems.items.length)
+        );
+        FulfillmentComponent[] memory considerationComponents = (
+            new FulfillmentComponent[](considerationItems.items.length)
+        );
 
         uint256 assignmentIndex = 0;
 
-        uint256 amountToConsume = offerItems.totalAmount > considerationItems.totalAmount
+        uint256 amountToConsume = offerItems.totalAmount >
+            considerationItems.totalAmount
             ? considerationItems.totalAmount
             : offerItems.totalAmount;
 
@@ -611,14 +790,18 @@ library FulfillmentGeneratorLib {
                     firstConsumedItemIndex = i;
                 }
 
-                offerComponents[assignmentIndex++] = getFulfillmentComponent(item);
+                offerComponents[assignmentIndex++] = getFulfillmentComponent(
+                    item
+                );
 
                 if (item.amount >= amountToConsume) {
                     uint256 amountToAddBack = item.amount - amountToConsume;
 
                     item.amount = 0;
 
-                    offerItems.items[firstConsumedItemIndex].amount += (amountToAddBack);
+                    offerItems.items[firstConsumedItemIndex].amount += (
+                        amountToAddBack
+                    );
 
                     offerItems.totalAmount -= amountToConsume;
 
@@ -635,7 +818,7 @@ library FulfillmentGeneratorLib {
 
         // Sanity check
         if (amountToConsume != 0) {
-            revert("FulfillmentGeneratorLib: did not consume expected amount");
+            revert DidNotConsumeExpectedAmount();
         }
 
         // Reduce offerComponents length based on number of elements assigned.
@@ -654,14 +837,18 @@ library FulfillmentGeneratorLib {
                     firstConsumedItemIndex = i;
                 }
 
-                considerationComponents[assignmentIndex++] = (getFulfillmentComponent(item));
+                considerationComponents[assignmentIndex++] = (
+                    getFulfillmentComponent(item)
+                );
 
                 if (item.amount >= amountToCredit) {
                     uint256 amountToAddBack = item.amount - amountToCredit;
 
                     item.amount = 0;
 
-                    considerationItems.items[firstConsumedItemIndex].amount += (amountToAddBack);
+                    considerationItems.items[firstConsumedItemIndex].amount += (
+                        amountToAddBack
+                    );
 
                     considerationItems.totalAmount -= amountToCredit;
 
@@ -678,7 +865,7 @@ library FulfillmentGeneratorLib {
 
         // Sanity check
         if (amountToCredit != 0) {
-            revert("FulfillmentGeneratorLib: did not credit expected amount");
+            revert DidNotCreditExpectedAmount();
         }
 
         // Reduce considerationComponents length based on # elements assigned.
@@ -687,11 +874,17 @@ library FulfillmentGeneratorLib {
         }
 
         // Sanity check
-        if (offerComponents.length == 0 || considerationComponents.length == 0) {
-            revert("FulfillmentGeneratorLib: empty match component generated");
+        if (
+            offerComponents.length == 0 || considerationComponents.length == 0
+        ) {
+            revert EmptyMatchComponentGenerated();
         }
 
-        return Fulfillment({offerComponents: offerComponents, considerationComponents: considerationComponents});
+        return
+            Fulfillment({
+                offerComponents: offerComponents,
+                considerationComponents: considerationComponents
+            });
     }
 
     function consumeRandomItemsAndGetFulfillment(
@@ -699,16 +892,21 @@ library FulfillmentGeneratorLib {
         FulfillmentItems memory considerationItems,
         uint256 seed
     ) internal pure returns (Fulfillment memory) {
-        if (offerItems.totalAmount == 0 || considerationItems.totalAmount == 0) {
-            revert("FulfillmentGeneratorLib: missing item amounts to consume");
+        if (
+            offerItems.totalAmount == 0 || considerationItems.totalAmount == 0
+        ) {
+            revert MissingItemAmountsToConsume();
         }
 
         // Allocate fulfillment component arrays using total items; reduce
         // length after based on the total number of elements assigned to each.
-        FulfillmentComponent[] memory offerComponents = (new FulfillmentComponent[](offerItems.items.length));
+        FulfillmentComponent[] memory offerComponents = (
+            new FulfillmentComponent[](offerItems.items.length)
+        );
 
-        FulfillmentComponent[] memory considerationComponents =
-            (new FulfillmentComponent[](considerationItems.items.length));
+        FulfillmentComponent[] memory considerationComponents = (
+            new FulfillmentComponent[](considerationItems.items.length)
+        );
 
         uint256[] memory consumableOfferIndices = new uint256[](
             offerItems.items.length
@@ -745,8 +943,11 @@ library FulfillmentGeneratorLib {
             }
 
             // Sanity check
-            if (consumableOfferIndices.length == 0 || consumableConsiderationIndices.length == 0) {
-                revert("FulfillmentGeneratorLib: did not find consumable items");
+            if (
+                consumableOfferIndices.length == 0 ||
+                consumableConsiderationIndices.length == 0
+            ) {
+                revert DidNotFindConsumableItems();
             }
 
             LibPRNG.PRNG memory prng;
@@ -761,7 +962,9 @@ library FulfillmentGeneratorLib {
                 mstore(consumableOfferIndices, assignmentIndex)
             }
 
-            assignmentIndex = prng.uniform(consumableConsiderationIndices.length) + 1;
+            assignmentIndex =
+                prng.uniform(consumableConsiderationIndices.length) +
+                1;
             assembly {
                 mstore(considerationComponents, assignmentIndex)
                 mstore(consumableConsiderationIndices, assignmentIndex)
@@ -772,7 +975,9 @@ library FulfillmentGeneratorLib {
         uint256 totalConsiderationAmount = 0;
 
         for (uint256 i = 0; i < consumableOfferIndices.length; ++i) {
-            FulfillmentItem memory item = offerItems.items[consumableOfferIndices[i]];
+            FulfillmentItem memory item = offerItems.items[
+                consumableOfferIndices[i]
+            ];
 
             offerComponents[i] = getFulfillmentComponent(item);
 
@@ -781,7 +986,9 @@ library FulfillmentGeneratorLib {
         }
 
         for (uint256 i = 0; i < consumableConsiderationIndices.length; ++i) {
-            FulfillmentItem memory item = considerationItems.items[consumableConsiderationIndices[i]];
+            FulfillmentItem memory item = considerationItems.items[
+                consumableConsiderationIndices[i]
+            ];
 
             considerationComponents[i] = getFulfillmentComponent(item);
 
@@ -790,29 +997,43 @@ library FulfillmentGeneratorLib {
         }
 
         if (totalOfferAmount > totalConsiderationAmount) {
-            uint256 remainingAmount = (totalOfferAmount - totalConsiderationAmount);
+            uint256 remainingAmount = (totalOfferAmount -
+                totalConsiderationAmount);
 
             // add back excess to first offer item
-            offerItems.items[consumableOfferIndices[0]].amount += (remainingAmount);
+            offerItems.items[consumableOfferIndices[0]].amount += (
+                remainingAmount
+            );
 
             offerItems.totalAmount -= totalConsiderationAmount;
             considerationItems.totalAmount -= totalConsiderationAmount;
         } else {
-            uint256 remainingAmount = (totalConsiderationAmount - totalOfferAmount);
+            uint256 remainingAmount = (totalConsiderationAmount -
+                totalOfferAmount);
 
             // add back excess to first consideration item
-            considerationItems.items[consumableConsiderationIndices[0]].amount += remainingAmount;
+            considerationItems
+                .items[consumableConsiderationIndices[0]]
+                .amount += remainingAmount;
 
             offerItems.totalAmount -= totalOfferAmount;
             considerationItems.totalAmount -= totalOfferAmount;
         }
 
-        return Fulfillment({offerComponents: offerComponents, considerationComponents: considerationComponents});
+        return
+            Fulfillment({
+                offerComponents: offerComponents,
+                considerationComponents: considerationComponents
+            });
     }
 
     function emptyFulfillment() internal pure returns (Fulfillment memory) {
         FulfillmentComponent[] memory components;
-        return Fulfillment({offerComponents: components, considerationComponents: components});
+        return
+            Fulfillment({
+                offerComponents: components,
+                considerationComponents: components
+            });
     }
 
     function getFulfillAvailableFulfillments(
@@ -828,55 +1049,81 @@ library FulfillmentGeneratorLib {
         )
     {
         ItemCategory[] memory offerCategories;
-        (offerFulfillments, offerCategories, considerationFulfillments,) = getFulfillmentComponentsUsingMethod(
-            fulfillAvailableDetails, getFulfillmentMethod(strategy.aggregationStrategy), seed
+        (
+            offerFulfillments,
+            offerCategories,
+            considerationFulfillments,
+
+        ) = getFulfillmentComponentsUsingMethod(
+            fulfillAvailableDetails,
+            getFulfillmentMethod(strategy.aggregationStrategy),
+            seed
         );
 
-        FulfillAvailableStrategy dropStrategy = (strategy.fulfillAvailableStrategy);
+        FulfillAvailableStrategy dropStrategy = (
+            strategy.fulfillAvailableStrategy
+        );
 
         if (dropStrategy == FulfillAvailableStrategy.KEEP_ALL) {
             return (offerFulfillments, considerationFulfillments);
         }
 
         if (dropStrategy == FulfillAvailableStrategy.DROP_SINGLE_OFFER) {
-            return (dropSingle(offerFulfillments, offerCategories), considerationFulfillments);
+            return (
+                dropSingle(offerFulfillments, offerCategories),
+                considerationFulfillments
+            );
         }
 
         if (dropStrategy == FulfillAvailableStrategy.DROP_ALL_OFFER) {
-            return (dropAllNon721(offerFulfillments, offerCategories), considerationFulfillments);
+            return (
+                dropAllNon721(offerFulfillments, offerCategories),
+                considerationFulfillments
+            );
         }
 
         if (dropStrategy == FulfillAvailableStrategy.DROP_RANDOM_OFFER) {
-            return (dropRandom(offerFulfillments, offerCategories, seed), considerationFulfillments);
+            return (
+                dropRandom(offerFulfillments, offerCategories, seed),
+                considerationFulfillments
+            );
         }
 
-        if (dropStrategy == FulfillAvailableStrategy.DROP_SINGLE_KEEP_FILTERED) {
-            revert("FulfillmentGeneratorLib: DROP_SINGLE_KEEP_FILTERED unsupported");
+        if (
+            dropStrategy == FulfillAvailableStrategy.DROP_SINGLE_KEEP_FILTERED
+        ) {
+            revert StrategyUnsupported();
         }
 
         if (dropStrategy == FulfillAvailableStrategy.DROP_ALL_KEEP_FILTERED) {
-            revert("FulfillmentGeneratorLib: DROP_ALL_KEEP_FILTERED unsupported");
+            revert StrategyUnsupported();
         }
 
-        if (dropStrategy == FulfillAvailableStrategy.DROP_RANDOM_KEEP_FILTERED) {
-            revert("FulfillmentGeneratorLib: DROP_RANDOM_KEEP_FILTERED unsupported");
+        if (
+            dropStrategy == FulfillAvailableStrategy.DROP_RANDOM_KEEP_FILTERED
+        ) {
+            revert StrategyUnsupported();
         }
 
-        revert("FulfillmentGeneratorLib: unknown fulfillAvailable strategy");
+        revert UnknownFulfillAvailableStrategy();
     }
 
-    function dropSingle(FulfillmentComponent[][] memory offerFulfillments, ItemCategory[] memory offerCategories)
-        internal
-        pure
-        returns (FulfillmentComponent[][] memory)
-    {
-        FulfillmentComponent[][] memory fulfillments = (new FulfillmentComponent[][](offerFulfillments.length));
+    function dropSingle(
+        FulfillmentComponent[][] memory offerFulfillments,
+        ItemCategory[] memory offerCategories
+    ) internal pure returns (FulfillmentComponent[][] memory) {
+        FulfillmentComponent[][] memory fulfillments = (
+            new FulfillmentComponent[][](offerFulfillments.length)
+        );
 
         uint256 assignmentIndex = 0;
 
         for (uint256 i = 0; i < offerFulfillments.length; ++i) {
             FulfillmentComponent[] memory components = offerFulfillments[i];
-            if (offerCategories[i] == ItemCategory.ERC721 || components.length > 1) {
+            if (
+                offerCategories[i] == ItemCategory.ERC721 ||
+                components.length > 1
+            ) {
                 fulfillments[assignmentIndex++] = components;
             }
         }
@@ -888,12 +1135,13 @@ library FulfillmentGeneratorLib {
         return fulfillments;
     }
 
-    function dropAllNon721(FulfillmentComponent[][] memory offerFulfillments, ItemCategory[] memory offerCategories)
-        internal
-        pure
-        returns (FulfillmentComponent[][] memory)
-    {
-        FulfillmentComponent[][] memory fulfillments = (new FulfillmentComponent[][](offerFulfillments.length));
+    function dropAllNon721(
+        FulfillmentComponent[][] memory offerFulfillments,
+        ItemCategory[] memory offerCategories
+    ) internal pure returns (FulfillmentComponent[][] memory) {
+        FulfillmentComponent[][] memory fulfillments = (
+            new FulfillmentComponent[][](offerFulfillments.length)
+        );
 
         uint256 assignmentIndex = 0;
 
@@ -919,13 +1167,18 @@ library FulfillmentGeneratorLib {
         LibPRNG.PRNG memory prng;
         prng.seed(seed ^ 0xbb);
 
-        FulfillmentComponent[][] memory fulfillments = (new FulfillmentComponent[][](offerFulfillments.length));
+        FulfillmentComponent[][] memory fulfillments = (
+            new FulfillmentComponent[][](offerFulfillments.length)
+        );
 
         uint256 assignmentIndex = 0;
 
         for (uint256 i = 0; i < offerFulfillments.length; ++i) {
             FulfillmentComponent[] memory components = offerFulfillments[i];
-            if (offerCategories[i] == ItemCategory.ERC721 || prng.uniform(2) == 0) {
+            if (
+                offerCategories[i] == ItemCategory.ERC721 ||
+                prng.uniform(2) == 0
+            ) {
                 fulfillments[assignmentIndex++] = components;
             }
         }
@@ -937,14 +1190,16 @@ library FulfillmentGeneratorLib {
         return fulfillments;
     }
 
-    function getFulfillmentMethod(AggregationStrategy aggregationStrategy)
+    function getFulfillmentMethod(
+        AggregationStrategy aggregationStrategy
+    )
         internal
         pure
         returns (
             function(FulfillmentItems[] memory, uint256)
-                                internal
-                                pure
-                                returns (FulfillmentComponent[][] memory, ItemCategory[] memory)
+                internal
+                pure
+                returns (FulfillmentComponent[][] memory, ItemCategory[] memory)
         )
     {
         if (aggregationStrategy == AggregationStrategy.MAXIMUM) {
@@ -954,7 +1209,7 @@ library FulfillmentGeneratorLib {
         } else if (aggregationStrategy == AggregationStrategy.RANDOM) {
             return getRandomFulfillmentComponents;
         } else {
-            revert("FulfillmentGeneratorLib: unknown aggregation strategy");
+            revert UnknownAggregationStrategy();
         }
     }
 
@@ -978,32 +1233,50 @@ library FulfillmentGeneratorLib {
             ItemCategory[] memory considerationCategories
         )
     {
-        (offerFulfillments, offerCategories) = fulfillmentMethod(fulfillAvailableDetails.items.offer, seed);
+        (offerFulfillments, offerCategories) = fulfillmentMethod(
+            fulfillAvailableDetails.items.offer,
+            seed
+        );
 
-        (considerationFulfillments, considerationCategories) =
-            fulfillmentMethod(fulfillAvailableDetails.items.consideration, seed);
+        (
+            considerationFulfillments,
+            considerationCategories
+        ) = fulfillmentMethod(
+            fulfillAvailableDetails.items.consideration,
+            seed
+        );
     }
 
-    function getMaxFulfillmentComponents(FulfillmentItems[] memory fulfillmentItems, uint256 /* seed */ )
+    function getMaxFulfillmentComponents(
+        FulfillmentItems[] memory fulfillmentItems,
+        uint256 /* seed */
+    )
         internal
         pure
         returns (FulfillmentComponent[][] memory, ItemCategory[] memory)
     {
-        FulfillmentComponent[][] memory fulfillments = (new FulfillmentComponent[][](fulfillmentItems.length));
+        FulfillmentComponent[][] memory fulfillments = (
+            new FulfillmentComponent[][](fulfillmentItems.length)
+        );
 
         ItemCategory[] memory categories = new ItemCategory[](
             fulfillmentItems.length
         );
 
         for (uint256 i = 0; i < fulfillmentItems.length; ++i) {
-            fulfillments[i] = getFulfillmentComponents(fulfillmentItems[i].items);
+            fulfillments[i] = getFulfillmentComponents(
+                fulfillmentItems[i].items
+            );
             categories[i] = fulfillmentItems[i].itemCategory;
         }
 
         return (fulfillments, categories);
     }
 
-    function getRandomFulfillmentComponents(FulfillmentItems[] memory fulfillmentItems, uint256 seed)
+    function getRandomFulfillmentComponents(
+        FulfillmentItems[] memory fulfillmentItems,
+        uint256 seed
+    )
         internal
         pure
         returns (FulfillmentComponent[][] memory, ItemCategory[] memory)
@@ -1014,7 +1287,9 @@ library FulfillmentGeneratorLib {
             fulfillmentCount += fulfillmentItems[i].items.length;
         }
 
-        FulfillmentComponent[][] memory fulfillments = (new FulfillmentComponent[][](fulfillmentCount));
+        FulfillmentComponent[][] memory fulfillments = (
+            new FulfillmentComponent[][](fulfillmentCount)
+        );
 
         ItemCategory[] memory categories = new ItemCategory[](fulfillmentCount);
 
@@ -1026,7 +1301,9 @@ library FulfillmentGeneratorLib {
             FulfillmentItem[] memory items = fulfillmentItems[i].items;
 
             for (uint256 j = 0; j < items.length; ++j) {
-                FulfillmentComponent[] memory fulfillment = (consumeRandomFulfillmentItems(items, prng));
+                FulfillmentComponent[] memory fulfillment = (
+                    consumeRandomFulfillmentItems(items, prng)
+                );
 
                 if (fulfillment.length == 0) {
                     break;
@@ -1049,9 +1326,13 @@ library FulfillmentGeneratorLib {
 
         prng.shuffle(componentIndices);
 
-        FulfillmentComponent[][] memory shuffledFulfillments = (new FulfillmentComponent[][](fulfillments.length));
+        FulfillmentComponent[][] memory shuffledFulfillments = (
+            new FulfillmentComponent[][](fulfillments.length)
+        );
 
-        ItemCategory[] memory shuffledCategories = (new ItemCategory[](fulfillments.length));
+        ItemCategory[] memory shuffledCategories = (
+            new ItemCategory[](fulfillments.length)
+        );
 
         for (uint256 i = 0; i < fulfillments.length; ++i) {
             uint256 priorIndex = componentIndices[i];
@@ -1062,11 +1343,10 @@ library FulfillmentGeneratorLib {
         return (shuffledFulfillments, shuffledCategories);
     }
 
-    function consumeRandomFulfillmentItems(FulfillmentItem[] memory items, LibPRNG.PRNG memory prng)
-        internal
-        pure
-        returns (FulfillmentComponent[] memory)
-    {
+    function consumeRandomFulfillmentItems(
+        FulfillmentItem[] memory items,
+        LibPRNG.PRNG memory prng
+    ) internal pure returns (FulfillmentComponent[] memory) {
         uint256[] memory consumableItemIndices = new uint256[](items.length);
         uint256 assignmentIndex = 0;
         for (uint256 i = 0; i < items.length; ++i) {
@@ -1106,7 +1386,10 @@ library FulfillmentGeneratorLib {
         return fulfillment;
     }
 
-    function getMinFulfillmentComponents(FulfillmentItems[] memory fulfillmentItems, uint256 /* seed */ )
+    function getMinFulfillmentComponents(
+        FulfillmentItems[] memory fulfillmentItems,
+        uint256 /* seed */
+    )
         internal
         pure
         returns (FulfillmentComponent[][] memory, ItemCategory[] memory)
@@ -1117,16 +1400,22 @@ library FulfillmentGeneratorLib {
             fulfillmentCount += fulfillmentItems[i].items.length;
         }
 
-        FulfillmentComponent[][] memory fulfillments = (new FulfillmentComponent[][](fulfillmentCount));
+        FulfillmentComponent[][] memory fulfillments = (
+            new FulfillmentComponent[][](fulfillmentCount)
+        );
 
-        ItemCategory[] memory categories = (new ItemCategory[](fulfillmentCount));
+        ItemCategory[] memory categories = (
+            new ItemCategory[](fulfillmentCount)
+        );
 
         fulfillmentCount = 0;
         for (uint256 i = 0; i < fulfillmentItems.length; ++i) {
             FulfillmentItem[] memory items = fulfillmentItems[i].items;
 
             for (uint256 j = 0; j < items.length; ++j) {
-                FulfillmentComponent[] memory fulfillment = (new FulfillmentComponent[](1));
+                FulfillmentComponent[] memory fulfillment = (
+                    new FulfillmentComponent[](1)
+                );
                 fulfillment[0] = getFulfillmentComponent(items[j]);
                 categories[fulfillmentCount] = fulfillmentItems[i].itemCategory;
                 fulfillments[fulfillmentCount++] = fulfillment;
@@ -1136,11 +1425,9 @@ library FulfillmentGeneratorLib {
         return (fulfillments, categories);
     }
 
-    function getFulfillmentComponents(FulfillmentItem[] memory items)
-        internal
-        pure
-        returns (FulfillmentComponent[] memory)
-    {
+    function getFulfillmentComponents(
+        FulfillmentItem[] memory items
+    ) internal pure returns (FulfillmentComponent[] memory) {
         FulfillmentComponent[] memory fulfillment = new FulfillmentComponent[](
             items.length
         );
@@ -1152,23 +1439,28 @@ library FulfillmentGeneratorLib {
         return fulfillment;
     }
 
-    function getFulfillmentComponent(FulfillmentItem memory item) internal pure returns (FulfillmentComponent memory) {
-        return FulfillmentComponent({orderIndex: item.orderIndex, itemIndex: item.itemIndex});
+    function getFulfillmentComponent(
+        FulfillmentItem memory item
+    ) internal pure returns (FulfillmentComponent memory) {
+        return
+            FulfillmentComponent({
+                orderIndex: item.orderIndex,
+                itemIndex: item.itemIndex
+            });
     }
 
-    function determineFulfillAvailableEligibility(FulfillAvailableDetails memory fulfillAvailableDetails)
-        internal
-        pure
-        returns (bool)
-    {
+    function determineFulfillAvailableEligibility(
+        FulfillAvailableDetails memory fulfillAvailableDetails
+    ) internal pure returns (bool) {
         bool atLeastOneExecution = false;
 
         FulfillmentItems[] memory offer = fulfillAvailableDetails.items.offer;
         for (uint256 i = 0; i < offer.length; ++i) {
             FulfillmentItems memory fulfillmentItems = offer[i];
             if (
-                fulfillmentItems.itemCategory == ItemCategory.NATIVE
-                    || (fulfillmentItems.itemCategory == ItemCategory.ERC721 && fulfillmentItems.totalAmount != 1)
+                fulfillmentItems.itemCategory == ItemCategory.NATIVE ||
+                (fulfillmentItems.itemCategory == ItemCategory.ERC721 &&
+                    fulfillmentItems.totalAmount != 1)
             ) {
                 return false;
             }
@@ -1188,10 +1480,15 @@ library FulfillmentGeneratorLib {
             }
         }
 
-        FulfillmentItems[] memory consideration = (fulfillAvailableDetails.items.consideration);
+        FulfillmentItems[] memory consideration = (
+            fulfillAvailableDetails.items.consideration
+        );
         for (uint256 i = 0; i < consideration.length; ++i) {
             FulfillmentItems memory fulfillmentItems = consideration[i];
-            if (fulfillmentItems.itemCategory == ItemCategory.ERC721 && fulfillmentItems.totalAmount != 1) {
+            if (
+                fulfillmentItems.itemCategory == ItemCategory.ERC721 &&
+                fulfillmentItems.totalAmount != 1
+            ) {
                 return false;
             }
 
@@ -1217,21 +1514,34 @@ library FulfillmentPrepLib {
     using MatchableItemReferenceGroupLib for MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[];
     using FulfillAvailableReferenceGroupLib for FulfillAvailableReferenceGroupLib.FulfillAvailableReferenceGroup;
 
+    error MismatchedItemCategories();
+    error EmptyItemReferencesSupplied();
+
     function getFulfillAvailableDetails(
         OrderDetails[] memory orderDetails,
         address recipient,
         address caller,
         uint256 seed
     ) internal pure returns (FulfillAvailableDetails memory) {
-        return getFulfillAvailableDetailsFromReferences(orderDetails.getItemReferences(seed), recipient, caller);
+        return
+            getFulfillAvailableDetailsFromReferences(
+                orderDetails.getItemReferences(seed),
+                recipient,
+                caller
+            );
     }
 
-    function getDetails(ItemReferenceLib.ItemReference[] memory itemReferences, address recipient, address caller)
+    function getDetails(
+        ItemReferenceLib.ItemReference[] memory itemReferences,
+        address recipient,
+        address caller
+    )
         internal
         pure
         returns (FulfillAvailableDetails memory, MatchDetails memory)
     {
-        ItemReferenceGroupLib.ItemReferenceGroup[] memory groups = itemReferences.bundleByAggregatable();
+        ItemReferenceGroupLib.ItemReferenceGroup[]
+            memory groups = itemReferences.bundleByAggregatable();
 
         return (
             groups.splitBySide(recipient, caller).getFulfillAvailableDetails(),
@@ -1244,31 +1554,42 @@ library FulfillmentPrepLib {
         address recipient,
         address caller
     ) internal pure returns (FulfillAvailableDetails memory) {
-        return itemReferences.bundleByAggregatable().splitBySide(recipient, caller).getFulfillAvailableDetails();
+        return
+            itemReferences
+                .bundleByAggregatable()
+                .splitBySide(recipient, caller)
+                .getFulfillAvailableDetails();
     }
 
-    function getMatchDetails(OrderDetails[] memory orderDetails, address recipient, uint256 seed)
-        internal
-        pure
-        returns (MatchDetails memory)
-    {
-        return getMatchDetailsFromReferences(orderDetails.getItemReferences(seed), recipient);
+    function getMatchDetails(
+        OrderDetails[] memory orderDetails,
+        address recipient,
+        uint256 seed
+    ) internal pure returns (MatchDetails memory) {
+        return
+            getMatchDetailsFromReferences(
+                orderDetails.getItemReferences(seed),
+                recipient
+            );
     }
 
-    function getMatchDetailsFromReferences(ItemReferenceLib.ItemReference[] memory itemReferences, address recipient)
-        internal
-        pure
-        returns (MatchDetails memory)
-    {
-        return itemReferences.bundleByAggregatable().bundleByMatchable(itemReferences).getMatchDetails(recipient);
+    function getMatchDetailsFromReferences(
+        ItemReferenceLib.ItemReference[] memory itemReferences,
+        address recipient
+    ) internal pure returns (MatchDetails memory) {
+        return
+            itemReferences
+                .bundleByAggregatable()
+                .bundleByMatchable(itemReferences)
+                .getMatchDetails(recipient);
     }
 
-    function getFulfillmentMatchContext(DualFulfillmentItems[] memory matchItems)
-        internal
-        pure
-        returns (DualFulfillmentMatchContext[] memory)
-    {
-        DualFulfillmentMatchContext[] memory context = (new DualFulfillmentMatchContext[](matchItems.length));
+    function getFulfillmentMatchContext(
+        DualFulfillmentItems[] memory matchItems
+    ) internal pure returns (DualFulfillmentMatchContext[] memory) {
+        DualFulfillmentMatchContext[] memory context = (
+            new DualFulfillmentMatchContext[](matchItems.length)
+        );
 
         for (uint256 i = 0; i < matchItems.length; ++i) {
             bool itemCategorySet = false;
@@ -1283,20 +1604,22 @@ library FulfillmentPrepLib {
                 if (!itemCategorySet) {
                     itemCategory = items.itemCategory;
                 } else if (itemCategory != items.itemCategory) {
-                    revert("FulfillmentPrepLib: mismatched item categories");
+                    revert MismatchedItemCategories();
                 }
 
                 totalOfferAmount += items.totalAmount;
             }
 
-            FulfillmentItems[] memory consideration = (matchItems[i].consideration);
+            FulfillmentItems[] memory consideration = (
+                matchItems[i].consideration
+            );
             for (uint256 j = 0; j < consideration.length; ++j) {
                 FulfillmentItems memory items = consideration[j];
 
                 if (!itemCategorySet) {
                     itemCategory = items.itemCategory;
                 } else if (itemCategory != items.itemCategory) {
-                    revert("FulfillmentPrepLib: mismatched item categories");
+                    revert MismatchedItemCategories();
                 }
 
                 totalConsiderationAmount += items.totalAmount;
@@ -1324,13 +1647,17 @@ library FulfillmentPrepLib {
         uint256 currentItems;
 
         for (uint256 i = 0; i < offerGroups.length; ++i) {
-            (items.offer[i], currentItems) = getFulfillmentItems(offerGroups[i].references);
+            (items.offer[i], currentItems) = getFulfillmentItems(
+                offerGroups[i].references
+            );
 
             totalItems += currentItems;
         }
 
         for (uint256 i = 0; i < considerationGroups.length; ++i) {
-            (items.consideration[i], currentItems) = getFulfillmentItems(considerationGroups[i].references);
+            (items.consideration[i], currentItems) = getFulfillmentItems(
+                considerationGroups[i].references
+            );
 
             totalItems += currentItems;
         }
@@ -1338,17 +1665,17 @@ library FulfillmentPrepLib {
         return (items, totalItems);
     }
 
-    function getFulfillmentItems(ItemReferenceLib.ItemReference[] memory itemReferences)
-        internal
-        pure
-        returns (FulfillmentItems memory, uint256 totalItems)
-    {
+    function getFulfillmentItems(
+        ItemReferenceLib.ItemReference[] memory itemReferences
+    ) internal pure returns (FulfillmentItems memory, uint256 totalItems) {
         // Sanity check: ensure there's at least one reference
         if (itemReferences.length == 0) {
-            revert("FulfillmentPrepLib: empty item references supplied");
+            revert EmptyItemReferencesSupplied();
         }
 
-        ItemReferenceLib.ItemReference memory firstReference = itemReferences[0];
+        ItemReferenceLib.ItemReference memory firstReference = itemReferences[
+            0
+        ];
         FulfillmentItems memory fulfillmentItems = FulfillmentItems({
             itemCategory: firstReference.itemCategory,
             totalAmount: 0,
@@ -1356,7 +1683,8 @@ library FulfillmentPrepLib {
         });
 
         for (uint256 i = 0; i < itemReferences.length; ++i) {
-            ItemReferenceLib.ItemReference memory itemReference = itemReferences[i];
+            ItemReferenceLib.ItemReference
+                memory itemReference = itemReferences[i];
             uint256 amount = itemReference.amount;
             fulfillmentItems.totalAmount += amount;
             fulfillmentItems.items[i] = FulfillmentItem({
@@ -1381,20 +1709,24 @@ library FulfillAvailableReferenceGroupLib {
         address caller;
     }
 
-    function getFulfillAvailableDetails(FulfillAvailableReferenceGroup memory group)
-        internal
-        pure
-        returns (FulfillAvailableDetails memory)
-    {
-        (DualFulfillmentItems memory items, uint256 totalItems) =
-            FulfillmentPrepLib.getDualFulfillmentItems(group.offerGroups, group.considerationGroups);
+    function getFulfillAvailableDetails(
+        FulfillAvailableReferenceGroup memory group
+    ) internal pure returns (FulfillAvailableDetails memory) {
+        (
+            DualFulfillmentItems memory items,
+            uint256 totalItems
+        ) = FulfillmentPrepLib.getDualFulfillmentItems(
+                group.offerGroups,
+                group.considerationGroups
+            );
 
-        return FulfillAvailableDetails({
-            items: items,
-            caller: group.caller,
-            recipient: group.recipient,
-            totalItems: totalItems
-        });
+        return
+            FulfillAvailableDetails({
+                items: items,
+                caller: group.caller,
+                recipient: group.recipient,
+                totalItems: totalItems
+            });
     }
 }
 
@@ -1407,11 +1739,10 @@ library MatchableItemReferenceGroupLib {
         uint256 considerationAssigned;
     }
 
-    function getMatchDetails(MatchableItemReferenceGroup[] memory matchableGroups, address recipient)
-        internal
-        pure
-        returns (MatchDetails memory)
-    {
+    function getMatchDetails(
+        MatchableItemReferenceGroup[] memory matchableGroups,
+        address recipient
+    ) internal pure returns (MatchDetails memory) {
         DualFulfillmentItems[] memory items = new DualFulfillmentItems[](
             matchableGroups.length
         );
@@ -1420,21 +1751,26 @@ library MatchableItemReferenceGroupLib {
         uint256 itemsInGroup = 0;
 
         for (uint256 i = 0; i < matchableGroups.length; ++i) {
-            MatchableItemReferenceGroup memory matchableGroup = (matchableGroups[i]);
-
-            (items[i], itemsInGroup) = FulfillmentPrepLib.getDualFulfillmentItems(
-                matchableGroup.offerGroups, matchableGroup.considerationGroups
+            MatchableItemReferenceGroup memory matchableGroup = (
+                matchableGroups[i]
             );
+
+            (items[i], itemsInGroup) = FulfillmentPrepLib
+                .getDualFulfillmentItems(
+                    matchableGroup.offerGroups,
+                    matchableGroup.considerationGroups
+                );
 
             totalItems += itemsInGroup;
         }
 
-        return MatchDetails({
-            items: items,
-            context: FulfillmentPrepLib.getFulfillmentMatchContext(items),
-            recipient: recipient,
-            totalItems: totalItems
-        });
+        return
+            MatchDetails({
+                items: items,
+                context: FulfillmentPrepLib.getFulfillmentMatchContext(items),
+                recipient: recipient,
+                totalItems: totalItems
+            });
     }
 }
 
@@ -1442,21 +1778,28 @@ library ItemReferenceGroupLib {
     using HashCountLib for ItemReferenceLib.ItemReference[];
     using HashAllocatorLib for HashCountLib.HashCount[];
 
+    error MissingItemReferenceInGroup();
+    error NoItemsInGroup();
+    error InvalidSideLocated();
+    error EmptyItemReferenceGroupSupplied();
+    error InvalidMatchSideLocated();
+
     struct ItemReferenceGroup {
         bytes32 fullHash;
         ItemReferenceLib.ItemReference[] references;
         uint256 assigned;
     }
 
-    function bundleByAggregatable(ItemReferenceLib.ItemReference[] memory itemReferences)
-        internal
-        pure
-        returns (ItemReferenceGroup[] memory)
-    {
-        ItemReferenceGroup[] memory groups = itemReferences.getUniqueFullHashes().allocateItemReferenceGroup();
+    function bundleByAggregatable(
+        ItemReferenceLib.ItemReference[] memory itemReferences
+    ) internal pure returns (ItemReferenceGroup[] memory) {
+        ItemReferenceGroup[] memory groups = itemReferences
+            .getUniqueFullHashes()
+            .allocateItemReferenceGroup();
 
         for (uint256 i = 0; i < itemReferences.length; ++i) {
-            ItemReferenceLib.ItemReference memory itemReference = itemReferences[i];
+            ItemReferenceLib.ItemReference
+                memory itemReference = itemReferences[i];
             for (uint256 j = 0; j < groups.length; ++j) {
                 ItemReferenceGroup memory group = groups[j];
                 if (group.fullHash == itemReference.fullHash) {
@@ -1469,21 +1812,32 @@ library ItemReferenceGroupLib {
         // Sanity check: ensure at least one reference item on each group
         for (uint256 i = 0; i < groups.length; ++i) {
             if (groups[i].references.length == 0) {
-                revert("ItemReferenceGroupLib: missing item reference in group");
+                revert MissingItemReferenceInGroup();
             }
         }
 
         return groups;
     }
 
-    function splitBySide(ItemReferenceGroup[] memory groups, address recipient, address caller)
+    function splitBySide(
+        ItemReferenceGroup[] memory groups,
+        address recipient,
+        address caller
+    )
         internal
         pure
-        returns (FulfillAvailableReferenceGroupLib.FulfillAvailableReferenceGroup memory)
+        returns (
+            FulfillAvailableReferenceGroupLib.FulfillAvailableReferenceGroup
+                memory
+        )
     {
         // NOTE: lengths are overallocated; reduce after assignment.
-        ItemReferenceGroup[] memory offerGroups = (new ItemReferenceGroup[](groups.length));
-        ItemReferenceGroup[] memory considerationGroups = (new ItemReferenceGroup[](groups.length));
+        ItemReferenceGroup[] memory offerGroups = (
+            new ItemReferenceGroup[](groups.length)
+        );
+        ItemReferenceGroup[] memory considerationGroups = (
+            new ItemReferenceGroup[](groups.length)
+        );
         uint256 offerItems = 0;
         uint256 considerationItems = 0;
 
@@ -1491,7 +1845,7 @@ library ItemReferenceGroupLib {
             ItemReferenceGroup memory group = groups[i];
 
             if (group.references.length == 0) {
-                revert("ItemReferenceGroupLib: no items in group");
+                revert NoItemsInGroup();
             }
 
             Side side = group.references[0].side;
@@ -1501,7 +1855,7 @@ library ItemReferenceGroupLib {
             } else if (side == Side.CONSIDERATION) {
                 considerationGroups[considerationItems++] = group;
             } else {
-                revert("ItemReferenceGroupLib: invalid side located (split)");
+                revert InvalidSideLocated();
             }
         }
 
@@ -1511,39 +1865,56 @@ library ItemReferenceGroupLib {
             mstore(considerationGroups, considerationItems)
         }
 
-        return FulfillAvailableReferenceGroupLib.FulfillAvailableReferenceGroup({
-            offerGroups: offerGroups,
-            considerationGroups: considerationGroups,
-            recipient: recipient,
-            caller: caller
-        });
+        return
+            FulfillAvailableReferenceGroupLib.FulfillAvailableReferenceGroup({
+                offerGroups: offerGroups,
+                considerationGroups: considerationGroups,
+                recipient: recipient,
+                caller: caller
+            });
     }
 
     function bundleByMatchable(
         ItemReferenceGroup[] memory groups,
         ItemReferenceLib.ItemReference[] memory itemReferences
-    ) internal pure returns (MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[] memory) {
-        MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[] memory matchableGroups =
-            (itemReferences.getUniqueDataHashes().allocateMatchableItemReferenceGroup());
+    )
+        internal
+        pure
+        returns (
+            MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[] memory
+        )
+    {
+        MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[]
+            memory matchableGroups = (
+                itemReferences
+                    .getUniqueDataHashes()
+                    .allocateMatchableItemReferenceGroup()
+            );
 
         for (uint256 i = 0; i < groups.length; ++i) {
             ItemReferenceGroup memory group = groups[i];
 
             if (group.references.length == 0) {
-                revert("ItemReferenceGroupLib: empty item reference group supplied");
+                revert EmptyItemReferenceGroupSupplied();
             }
 
-            ItemReferenceLib.ItemReference memory firstReference = group.references[0];
+            ItemReferenceLib.ItemReference memory firstReference = group
+                .references[0];
             for (uint256 j = 0; j < matchableGroups.length; ++j) {
-                MatchableItemReferenceGroupLib.MatchableItemReferenceGroup memory matchableGroup = (matchableGroups[j]);
+                MatchableItemReferenceGroupLib.MatchableItemReferenceGroup
+                    memory matchableGroup = (matchableGroups[j]);
 
                 if (matchableGroup.dataHash == firstReference.dataHash) {
                     if (firstReference.side == Side.OFFER) {
-                        matchableGroup.offerGroups[matchableGroup.offerAssigned++] = group;
+                        matchableGroup.offerGroups[
+                            matchableGroup.offerAssigned++
+                        ] = group;
                     } else if (firstReference.side == Side.CONSIDERATION) {
-                        matchableGroup.considerationGroups[matchableGroup.considerationAssigned++] = group;
+                        matchableGroup.considerationGroups[
+                            matchableGroup.considerationAssigned++
+                        ] = group;
                     } else {
-                        revert("ItemReferenceGroupLib: invalid match side located");
+                        revert InvalidMatchSideLocated();
                     }
 
                     break;
@@ -1553,11 +1924,14 @@ library ItemReferenceGroupLib {
 
         // Reduce reference group array lengths based on assigned elements.
         for (uint256 i = 0; i < matchableGroups.length; ++i) {
-            MatchableItemReferenceGroupLib.MatchableItemReferenceGroup memory group = matchableGroups[i];
+            MatchableItemReferenceGroupLib.MatchableItemReferenceGroup
+                memory group = matchableGroups[i];
             uint256 offerAssigned = group.offerAssigned;
             uint256 considerationAssigned = group.considerationAssigned;
             ItemReferenceGroup[] memory offerGroups = (group.offerGroups);
-            ItemReferenceGroup[] memory considerationGroups = (group.considerationGroups);
+            ItemReferenceGroup[] memory considerationGroups = (
+                group.considerationGroups
+            );
 
             assembly {
                 mstore(offerGroups, offerAssigned)
@@ -1570,12 +1944,15 @@ library ItemReferenceGroupLib {
 }
 
 library HashAllocatorLib {
-    function allocateItemReferenceGroup(HashCountLib.HashCount[] memory hashCount)
+    function allocateItemReferenceGroup(
+        HashCountLib.HashCount[] memory hashCount
+    )
         internal
         pure
         returns (ItemReferenceGroupLib.ItemReferenceGroup[] memory)
     {
-        ItemReferenceGroupLib.ItemReferenceGroup[] memory group = new ItemReferenceGroupLib.ItemReferenceGroup[](
+        ItemReferenceGroupLib.ItemReferenceGroup[]
+            memory group = new ItemReferenceGroupLib.ItemReferenceGroup[](
                 hashCount.length
             );
 
@@ -1583,8 +1960,8 @@ library HashAllocatorLib {
             group[i] = ItemReferenceGroupLib.ItemReferenceGroup({
                 fullHash: hashCount[i].hash,
                 references: new ItemReferenceLib.ItemReference[](
-                            hashCount[i].count
-                        ),
+                    hashCount[i].count
+                ),
                 assigned: 0
             });
         }
@@ -1592,30 +1969,38 @@ library HashAllocatorLib {
         return group;
     }
 
-    function allocateMatchableItemReferenceGroup(HashCountLib.HashCount[] memory hashCount)
+    function allocateMatchableItemReferenceGroup(
+        HashCountLib.HashCount[] memory hashCount
+    )
         internal
         pure
-        returns (MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[] memory)
+        returns (
+            MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[] memory
+        )
     {
-        MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[] memory group = (
-            new MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[](
+        MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[]
+            memory group = (
+                new MatchableItemReferenceGroupLib.MatchableItemReferenceGroup[](
                     hashCount.length
                 )
-        );
+            );
 
         for (uint256 i = 0; i < hashCount.length; ++i) {
             // NOTE: reference group lengths are overallocated and will need to
             // be reduced once their respective elements have been assigned.
             uint256 count = hashCount[i].count;
-            group[i] = MatchableItemReferenceGroupLib.MatchableItemReferenceGroup({
-                dataHash: hashCount[i].hash,
-                offerGroups: new ItemReferenceGroupLib.ItemReferenceGroup[](
-                                count
-                            ),
-                considerationGroups: (new ItemReferenceGroupLib.ItemReferenceGroup[](count)),
-                offerAssigned: 0,
-                considerationAssigned: 0
-            });
+            group[i] = MatchableItemReferenceGroupLib
+                .MatchableItemReferenceGroup({
+                    dataHash: hashCount[i].hash,
+                    offerGroups: new ItemReferenceGroupLib.ItemReferenceGroup[](
+                        count
+                    ),
+                    considerationGroups: (
+                        new ItemReferenceGroupLib.ItemReferenceGroup[](count)
+                    ),
+                    offerAssigned: 0,
+                    considerationAssigned: 0
+                });
         }
 
         return group;
@@ -1633,11 +2018,9 @@ library HashCountLib {
         uint256 count;
     }
 
-    function getUniqueFullHashes(ItemReferenceLib.ItemReference[] memory itemReferences)
-        internal
-        pure
-        returns (HashCount[] memory)
-    {
+    function getUniqueFullHashes(
+        ItemReferenceLib.ItemReference[] memory itemReferences
+    ) internal pure returns (HashCount[] memory) {
         uint256[] memory fullHashes = new uint256[](itemReferences.length);
 
         for (uint256 i = 0; i < itemReferences.length; ++i) {
@@ -1647,11 +2030,9 @@ library HashCountLib {
         return getHashCount(fullHashes);
     }
 
-    function getUniqueDataHashes(ItemReferenceLib.ItemReference[] memory itemReferences)
-        internal
-        pure
-        returns (HashCount[] memory)
-    {
+    function getUniqueDataHashes(
+        ItemReferenceLib.ItemReference[] memory itemReferences
+    ) internal pure returns (HashCount[] memory) {
         uint256[] memory dataHashes = new uint256[](itemReferences.length);
 
         for (uint256 i = 0; i < itemReferences.length; ++i) {
@@ -1661,7 +2042,9 @@ library HashCountLib {
         return getHashCount(dataHashes);
     }
 
-    function getHashCount(uint256[] memory hashes) internal pure returns (HashCount[] memory) {
+    function getHashCount(
+        uint256[] memory hashes
+    ) internal pure returns (HashCount[] memory) {
         if (hashes.length == 0) {
             return new HashCount[](0);
         }
@@ -1669,14 +2052,17 @@ library HashCountLib {
         hashes.sort();
 
         HashCount[] memory hashCount = new HashCount[](hashes.length);
-        hashCount[0] = HashCount({hash: bytes32(hashes[0]), count: 1});
+        hashCount[0] = HashCount({ hash: bytes32(hashes[0]), count: 1 });
 
         uint256 hashCountPointer = 0;
         for (uint256 i = 1; i < hashes.length; ++i) {
             bytes32 element = bytes32(hashes[i]);
 
             if (element != hashCount[hashCountPointer].hash) {
-                hashCount[++hashCountPointer] = HashCount({hash: element, count: 1});
+                hashCount[++hashCountPointer] = HashCount({
+                    hash: element,
+                    count: 1
+                });
             } else {
                 ++hashCount[hashCountPointer].count;
             }
@@ -1695,6 +2081,9 @@ library ItemReferenceLib {
     using LibPRNG for LibPRNG.PRNG;
     using LibSort for uint256[];
 
+    error InvalidItemTypeLocated();
+    error InvalidSideLocated();
+
     struct ItemReference {
         uint256 orderIndex;
         uint256 itemIndex;
@@ -1706,26 +2095,45 @@ library ItemReferenceLib {
         address account;
     }
 
-    function getItemReferences(OrderDetails[] memory orderDetails, uint256 seed)
-        internal
-        pure
-        returns (ItemReference[] memory)
-    {
+    function getItemReferences(
+        OrderDetails[] memory orderDetails,
+        uint256 seed
+    ) internal pure returns (ItemReference[] memory) {
         ItemReference[] memory itemReferences = new ItemReference[](
             getTotalItems(orderDetails)
         );
 
         uint256 itemReferenceIndex = 0;
 
-        for (uint256 orderIndex = 0; orderIndex < orderDetails.length; ++orderIndex) {
+        for (
+            uint256 orderIndex = 0;
+            orderIndex < orderDetails.length;
+            ++orderIndex
+        ) {
             OrderDetails memory order = orderDetails[orderIndex];
-            for (uint256 itemIndex = 0; itemIndex < order.offer.length; ++itemIndex) {
-                itemReferences[itemReferenceIndex++] =
-                    getItemReference(order.offer[itemIndex], orderIndex, itemIndex, order.offerer, order.conduitKey);
+            for (
+                uint256 itemIndex = 0;
+                itemIndex < order.offer.length;
+                ++itemIndex
+            ) {
+                itemReferences[itemReferenceIndex++] = getItemReference(
+                    order.offer[itemIndex],
+                    orderIndex,
+                    itemIndex,
+                    order.offerer,
+                    order.conduitKey
+                );
             }
-            for (uint256 itemIndex = 0; itemIndex < order.consideration.length; ++itemIndex) {
-                itemReferences[itemReferenceIndex++] =
-                    getItemReference(order.consideration[itemIndex], orderIndex, itemIndex);
+            for (
+                uint256 itemIndex = 0;
+                itemIndex < order.consideration.length;
+                ++itemIndex
+            ) {
+                itemReferences[itemReferenceIndex++] = getItemReference(
+                    order.consideration[itemIndex],
+                    orderIndex,
+                    itemIndex
+                );
             }
         }
 
@@ -1736,11 +2144,10 @@ library ItemReferenceLib {
         return shuffle(itemReferences, seed);
     }
 
-    function shuffle(ItemReference[] memory itemReferences, uint256 seed)
-        internal
-        pure
-        returns (ItemReference[] memory)
-    {
+    function shuffle(
+        ItemReference[] memory itemReferences,
+        uint256 seed
+    ) internal pure returns (ItemReference[] memory) {
         ItemReference[] memory shuffledItemReferences = new ItemReference[](
             itemReferences.length
         );
@@ -1768,35 +2175,37 @@ library ItemReferenceLib {
         address offerer,
         bytes32 conduitKey
     ) internal pure returns (ItemReference memory) {
-        return getItemReference(
-            orderIndex,
-            itemIndex,
-            Side.OFFER,
-            item.itemType,
-            item.token,
-            item.identifier,
-            offerer,
-            conduitKey,
-            item.amount
-        );
+        return
+            getItemReference(
+                orderIndex,
+                itemIndex,
+                Side.OFFER,
+                item.itemType,
+                item.token,
+                item.identifier,
+                offerer,
+                conduitKey,
+                item.amount
+            );
     }
 
-    function getItemReference(ReceivedItem memory item, uint256 orderIndex, uint256 itemIndex)
-        internal
-        pure
-        returns (ItemReference memory)
-    {
-        return getItemReference(
-            orderIndex,
-            itemIndex,
-            Side.CONSIDERATION,
-            item.itemType,
-            item.token,
-            item.identifier,
-            item.recipient,
-            bytes32(0),
-            item.amount
-        );
+    function getItemReference(
+        ReceivedItem memory item,
+        uint256 orderIndex,
+        uint256 itemIndex
+    ) internal pure returns (ItemReference memory) {
+        return
+            getItemReference(
+                orderIndex,
+                itemIndex,
+                Side.CONSIDERATION,
+                item.itemType,
+                item.token,
+                item.identifier,
+                item.recipient,
+                bytes32(0),
+                item.amount
+            );
     }
 
     function getItemReference(
@@ -1810,15 +2219,19 @@ library ItemReferenceLib {
         bytes32 conduitKey,
         uint256 amount
     ) internal pure returns (ItemReference memory) {
-        bytes32 dataHash = keccak256(abi.encodePacked(itemType, token, identifier));
+        bytes32 dataHash = keccak256(
+            abi.encodePacked(itemType, token, identifier)
+        );
 
         bytes32 fullHash;
         if (side == Side.OFFER) {
-            fullHash = keccak256(abi.encodePacked(dataHash, account, conduitKey));
+            fullHash = keccak256(
+                abi.encodePacked(dataHash, account, conduitKey)
+            );
         } else if (side == Side.CONSIDERATION) {
             fullHash = keccak256(abi.encodePacked(dataHash, account));
         } else {
-            revert("ItemReferenceLib: invalid side located");
+            revert InvalidSideLocated();
         }
 
         ItemCategory itemCategory;
@@ -1826,25 +2239,33 @@ library ItemReferenceLib {
             itemCategory = ItemCategory.NATIVE;
         } else if (itemType == ItemType.ERC721) {
             itemCategory = ItemCategory.ERC721;
-        } else if (itemType == ItemType.ERC20 || itemType == ItemType.ERC1155) {
+        } else if (
+            itemType == ItemType.ERC20 ||
+            itemType == ItemType.ERC1155 ||
+            itemType == ItemType.ERC1155_WITH_CRITERIA ||
+            itemType == ItemType.ERC721_WITH_CRITERIA
+        ) {
             itemCategory = ItemCategory.OTHER;
         } else {
-            revert("ItemReferenceLib: invalid item type located");
+            revert InvalidItemTypeLocated();
         }
 
-        return ItemReference({
-            orderIndex: orderIndex,
-            itemIndex: itemIndex,
-            side: side,
-            dataHash: dataHash,
-            fullHash: fullHash,
-            amount: amount,
-            itemCategory: itemCategory,
-            account: account
-        });
+        return
+            ItemReference({
+                orderIndex: orderIndex,
+                itemIndex: itemIndex,
+                side: side,
+                dataHash: dataHash,
+                fullHash: fullHash,
+                amount: amount,
+                itemCategory: itemCategory,
+                account: account
+            });
     }
 
-    function getTotalItems(OrderDetails[] memory orderDetails) internal pure returns (uint256) {
+    function getTotalItems(
+        OrderDetails[] memory orderDetails
+    ) internal pure returns (uint256) {
         uint256 totalItems = 0;
 
         for (uint256 i = 0; i < orderDetails.length; ++i) {
@@ -1854,7 +2275,9 @@ library ItemReferenceLib {
         return totalItems;
     }
 
-    function getTotalItems(OrderDetails memory order) internal pure returns (uint256) {
+    function getTotalItems(
+        OrderDetails memory order
+    ) internal pure returns (uint256) {
         return (order.offer.length + order.consideration.length);
     }
 }


### PR DESCRIPTION
- Swap out error strings for custom errors in `FulfillmentLib` and helpers. 
- Extract `DefaultFulfillmentLib` from `FulfillmentLib`.

(This gets `FulfillmentLib` below the codesize limit so it's usable on chain).